### PR TITLE
iotlabmqtt: add support for broker user/password auth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,14 @@ Broker port, defaults to 1883 (when I wrote it)::
 
    --broker-port BROKER_PORT
 
+Broker authentication username::
+
+   --broker-username USERNAME
+
+Broker authentication password (should be used with ``--broker-username``)::
+
+   --broker-password PASSWORD
+
 Topics prefix, your topic namespace::
 
    --prefix PREFIX

--- a/examples/process_client.py
+++ b/examples/process_client.py
@@ -47,6 +47,12 @@ To see how topics are used, you can use the log client:
 
    iotlab-mqtt-clients log --prefix PREFIX BROKER
 
+
+.. note::
+
+   You can also provide --broker-username and --broker-password to configure
+   broker authentication.
+
 """
 
 from __future__ import (absolute_import, division, print_function,

--- a/iotlabmqtt/common.py
+++ b/iotlabmqtt/common.py
@@ -112,6 +112,10 @@ class MQTTAgentArgumentParser(argparse.ArgumentParser):
     def _add_common_arguments(self):
         """Add common agents arguments to parser."""
         self.add_argument('--prefix', help='Topics prefix', default='')
+        self.add_argument('--broker-username',
+                          help='Broker authentication user')
+        self.add_argument('--broker-password',
+                          help='Broker authentication password')
         self.add_argument('--broker-port', help='Broker port')
         self.add_argument('broker', help='Broker address')
 

--- a/iotlabmqtt/tests/integration_tests/files/mosquitto.conf
+++ b/iotlabmqtt/tests/integration_tests/files/mosquitto.conf
@@ -1,0 +1,4 @@
+log_type error
+log_type warning
+allow_anonymous false
+password_file {password_file}

--- a/iotlabmqtt/tests/integration_tests/files/mosquitto.passwd
+++ b/iotlabmqtt/tests/integration_tests/files/mosquitto.passwd
@@ -1,0 +1,1 @@
+iotlabmqtt:$6$GvXCIIOs9AgrMJCc$RnlYKCdP2y88n8niw6mQfj/pcgpTiYaG2InZkj6hlkQiaGmX6NoNAqmZQyAEn7GUhmChWm6t54H0Yp6LD3ofAw==

--- a/iotlabmqtt/tests/integration_tests/log_integration_test.py
+++ b/iotlabmqtt/tests/integration_tests/log_integration_test.py
@@ -33,6 +33,8 @@ class LogIntegrationTest(IntegrationTestCase):
         Yields client and stdout mock.
         """
         args = ['localhost', '--broker-port', '%s' % brokerport,
+                '--broker-username', self.mqttuser,
+                '--broker-password', self.mqttpassword,
                 '--prefix', self.prefix]
         opts = log_client.PARSER.parse_args(args)
 

--- a/iotlabmqtt/tests/integration_tests/mosquitto.conf
+++ b/iotlabmqtt/tests/integration_tests/mosquitto.conf
@@ -1,2 +1,0 @@
-log_type error
-log_type warning

--- a/iotlabmqtt/tests/integration_tests/mqttcommon_integration_test.py
+++ b/iotlabmqtt/tests/integration_tests/mqttcommon_integration_test.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Integration tests for IoT-LAB MQTT mqttcommon."""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from builtins import *  # pylint:disable=W0401,W0614,W0622
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import mock
+
+from iotlabmqtt import common
+from iotlabmqtt import mqttcommon
+from . import IntegrationTestCase
+
+
+class MQTTClientIntegrationTest(IntegrationTestCase):
+    """Test MQTTClient using a broker."""
+    # pylint:disable=invalid-name
+
+    def test_connect_without_user_password(self):
+        """Test connecting fail not authorized with authenticated broker."""
+        # Not giving user password
+        args = ['localhost', '--broker-port', '%s' % self.BROKERPORT]
+        opts = common.MQTTAgentArgumentParser().parse_args(args)
+
+        client = mqttcommon.MQTTClient.from_opts_dict(**vars(opts))
+
+        with mock.patch('sys.stderr', new_callable=StringIO) as stderr:
+            self.assertRaises(RuntimeError, client.start)
+
+        # Auth failed
+        not_authorized = 'RuntimeError: Connection refused: "not authorized"'
+        self.assertTrue(not_authorized in stderr.getvalue())
+
+        # NOTE: this is not seen in the output, but it is when run from command
+        # line, so I don't know why...
+        #
+        # Also check that it failed because of topics timeout
+        # (could be handled correctly with the real error but no time now)
+        # self.assertTrue(sub_timeout in stderr.getvalue())

--- a/iotlabmqtt/tests/integration_tests/node_integration_test.py
+++ b/iotlabmqtt/tests/integration_tests/node_integration_test.py
@@ -32,6 +32,8 @@ class NodeIntegrationTest(IntegrationTestCase):
         """
         # pylint:disable=attribute-defined-outside-init
         args = ['localhost', '--broker-port', '%s' % brokerport,
+                '--broker-username', self.mqttuser,
+                '--broker-password', self.mqttpassword,
                 '--prefix', 'node/test/prefix']
         args += ['--experiment-id', '12345',
                  '--iotlab-user', 'us3rn4me',
@@ -51,6 +53,8 @@ class NodeIntegrationTest(IntegrationTestCase):
 
         try:
             args = ['localhost', '--broker-port', '%s' % brokerport,
+                    '--broker-username', self.mqttuser,
+                    '--broker-password', self.mqttpassword,
                     '--prefix', 'node/test/prefix',
                     '--site', server.HOSTNAME]
             opts = node_client.PARSER.parse_args(args)

--- a/iotlabmqtt/tests/integration_tests/process_integration_test.py
+++ b/iotlabmqtt/tests/integration_tests/process_integration_test.py
@@ -42,6 +42,8 @@ class ProcessIntegrationTests(IntegrationTestCase):
         """
         # pylint:disable=attribute-defined-outside-init
         args = ['localhost', '--broker-port', '%s' % brokerport,
+                '--broker-username', self.mqttuser,
+                '--broker-password', self.mqttpassword,
                 '--prefix', 'process/test/prefix']
         opts = process.PARSER.parse_args(args)
         server = process.MQTTProcessAgent.from_opts_dict(**vars(opts))
@@ -49,6 +51,8 @@ class ProcessIntegrationTests(IntegrationTestCase):
         self.server = server
         try:
             args = ['localhost', '--broker-port', '%s' % brokerport,
+                    '--broker-username', self.mqttuser,
+                    '--broker-password', self.mqttpassword,
                     '--prefix', 'process/test/prefix',
                     '--site', server.HOSTNAME]
             opts = process_client.PARSER.parse_args(args)

--- a/iotlabmqtt/tests/integration_tests/radiosniffer_integration_test.py
+++ b/iotlabmqtt/tests/integration_tests/radiosniffer_integration_test.py
@@ -69,6 +69,8 @@ class RadioSnifferIntegrationTest(IntegrationTestCase):
         """
         # pylint:disable=attribute-defined-outside-init
         args = ['localhost', '--broker-port', '%s' % brokerport,
+                '--broker-username', self.mqttuser,
+                '--broker-password', self.mqttpassword,
                 '--prefix', 'radiosniffer/test/prefix']
         args += ['--experiment-id', '12345',
                  '--iotlab-user', 'us3rn4me',
@@ -91,6 +93,8 @@ class RadioSnifferIntegrationTest(IntegrationTestCase):
 
         try:
             args = ['localhost', '--broker-port', '%s' % brokerport,
+                    '--broker-username', self.mqttuser,
+                    '--broker-password', self.mqttpassword,
                     '--prefix', 'radiosniffer/test/prefix',
                     '--site', server.HOSTNAME]
             opts = radiosniffer_client.PARSER.parse_args(args)

--- a/iotlabmqtt/tests/integration_tests/serial_integration_test.py
+++ b/iotlabmqtt/tests/integration_tests/serial_integration_test.py
@@ -32,14 +32,15 @@ class SerialIntegrationTest(IntegrationTestCase):
         for port in list(self.socat):
             self.socat_stop(port)
 
-    @staticmethod
     @contextlib.contextmanager
-    def start_client_and_server(brokerport):
+    def start_client_and_server(self, brokerport):
         """Start serial client and server context manager.
 
         Yields client and stdout mock.
         """
         args = ['localhost', '--broker-port', '%s' % brokerport,
+                '--broker-username', self.mqttuser,
+                '--broker-password', self.mqttpassword,
                 '--prefix', 'serial/test/prefix']
         opts = serial.PARSER.parse_args(args)
         server = serial.MQTTAggregator.from_opts_dict(**vars(opts))
@@ -47,6 +48,8 @@ class SerialIntegrationTest(IntegrationTestCase):
 
         try:
             args = ['localhost', '--broker-port', '%s' % brokerport,
+                    '--broker-username', self.mqttuser,
+                    '--broker-password', self.mqttpassword,
                     '--prefix', 'serial/test/prefix',
                     '--site', server.HOSTNAME]
             opts = serial_client.PARSER.parse_args(args)


### PR DESCRIPTION
Add two new options '--broker-username' and '--broker-password' to set broker
authentication username and password.

WARNING: This should be changed, setting a password from command line is really bad. On IoT-LAB all users can see other users commands arguments. A solution could be to use an env variable.