### PR TITLE
Wb/manager

### DIFF
--- a/doc/source/agents.rst
+++ b/doc/source/agents.rst
@@ -4,6 +4,7 @@ Agents
 .. toctree::
    :maxdepth: 1
 
+   agents/manager
    agents/serial
    agents/radiosniffer
    agents/node

--- a/doc/source/agents.rst
+++ b/doc/source/agents.rst
@@ -1,10 +1,16 @@
-Agents
-******
+Manager Agent
+*************
 
 .. toctree::
    :maxdepth: 1
 
    agents/manager
+
+Task Agents
+***********
+.. toctree::
+   :maxdepth: 1
+
    agents/serial
    agents/radiosniffer
    agents/node

--- a/doc/source/agents/manager.rst
+++ b/doc/source/agents/manager.rst
@@ -1,0 +1,4 @@
+Manager Agent
+=============
+
+.. automodule:: iotlabmqtt.manager

--- a/doc/source/agents/manager.rst
+++ b/doc/source/agents/manager.rst
@@ -1,4 +1,4 @@
-Manager Agent
-=============
+IoT-LAB Manager Agent
+=====================
 
 .. automodule:: iotlabmqtt.manager

--- a/examples/manager_config.cfg
+++ b/examples/manager_config.cfg
@@ -1,0 +1,11 @@
+[DEFAULT]
+--prefix = prefix/name/{expid}/{user}
+--broker-port = 8883
+--broker-username = USERNME
+--broker-username = PASSWORD
+--iotlab-user = IOTLAB_USERNAME
+--iotlab-password = IOTLAB_PASSWORD
+# Automatically deduced values when used with 'run_script'
+# If run manually set the value
+# --experiment-id
+broker = BROKER_URL

--- a/iotlab-mqtt-manager
+++ b/iotlab-mqtt-manager
@@ -1,0 +1,4 @@
+#! /usr/bin/env python
+
+import iotlabmqtt.manager
+iotlabmqtt.manager.main()

--- a/iotlabmqtt/common.py
+++ b/iotlabmqtt/common.py
@@ -167,9 +167,17 @@ def synchronized(lockname):
     return _wrapper
 
 
+def _to_keyboardinterrupt(*_):
+    """Convert signal to SIGINT."""
+    raise KeyboardInterrupt()
+
+
 def wait_sigint():
-    """Pause until Ctrl+C."""
+    """Pause until Ctrl+C or SIGTERM."""
     try:
+        signal.signal(signal.SIGTERM, _to_keyboardinterrupt)
         signal.pause()
     except KeyboardInterrupt:
         pass
+    finally:
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)

--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -55,6 +55,16 @@ class IoTLABAPI(object):
 
         assert self.expid is not None
 
+    @property
+    def username(self):
+        """Return IoT-LAB username."""
+        return self.api.auth.username
+
+    @property
+    def password(self):
+        """Return IoT-LAB password."""
+        return self.api.auth.password
+
     @staticmethod
     def _user_password(user, password):
         """Load username password from files if not defined."""

--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -123,6 +123,14 @@ class IoTLABAPI(object):
         """Create class from argparse entries."""
         return cls(iotlab_username, iotlab_password, experiment_id)
 
+    def to_argparse_list(self):
+        """Return arguments needed to create this object with PARSER."""
+        return [
+            '--iotlab-user', '%s' % self.username,
+            '--iotlab-password', '%s' % self.password,
+            '--experiment-id', '%s' % self.expid,
+        ]
+
     def set_sniffer_channel(self, channel, archi, *nums):
         """Set sniffer on ``channel`` for nodes ``archi`` and ``*nums``."""
         return self._update_profile(channel, archi, *nums)

--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from builtins import *  # pylint:disable=W0401,W0614,W0622
 
+import os
 import tempfile
 
 from . import common
@@ -35,6 +36,8 @@ class IoTLABAPI(object):
         'Provide ``--iotlab-user`` and ``--iotlab-password`` options.\n'
         'Or register them using ``auth-cli --user USERNAME``'
     )
+
+    EXP_ID_ENV_VARIABLE = 'EXP_ID'  # variable is set by 'runscript'
 
     def __init__(self, user=None, password=None, experiment_id=None):
         import iotlabcli.rest
@@ -76,10 +79,16 @@ class IoTLABAPI(object):
             print(err)
             exit(1)
 
-    @staticmethod
-    def _experiment_id(api, experiment_id):
+    @classmethod
+    def _experiment_id(cls, api, experiment_id):
         """Try getting experiment_id if not provided."""
         import iotlabcli.helpers
+
+        # Try loading experiment_id from environment variable
+        env_expid = os.environ.get(cls.EXP_ID_ENV_VARIABLE)
+        if not experiment_id and env_expid:
+            return int(env_expid)
+
         return iotlabcli.helpers.get_current_experiment(api, experiment_id)
 
     @classmethod

--- a/iotlabmqtt/manager.py
+++ b/iotlabmqtt/manager.py
@@ -101,6 +101,19 @@ class MQTTManagerAgent(process.MQTTProcessAgent):
 
         self.process_args_dict = process_args_dict
 
+    # Override prockill to set a different kill timeout
+    def cb_prockill(self, _, procid):
+        """Kill given process.
+
+        Overrides Process method to increase kill timeout.
+        Agents can take more time to stop.
+        """
+        try:
+            proc = self.process[procid]
+            return proc.kill(timeout=5).encode('utf-8')
+        except KeyError:
+            return ('Name %s not found' % procid).encode('utf-8')
+
     # Disable unused 'Process' methods
 
     def cb_new(self, _):

--- a/iotlabmqtt/manager.py
+++ b/iotlabmqtt/manager.py
@@ -1,0 +1,215 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from builtins import *  # pylint:disable=W0401,W0614,W0622
+
+try:
+    import ConfigParser as configparser
+except ImportError:  # pragma: no cover
+    import configparser
+
+import sys
+import argparse
+
+from . import common
+from . import iotlabapi
+from . import mqttcommon
+from . import process
+
+
+EPILOG = (
+    'Options can also be set by giving a `CONFIG_FILE` path.\n'
+    'Where the config file format is:\n'
+    '\n'
+    '    [DEFAULT]\n'
+    '    --broker-port = 8883\n'
+    '    # --any-other-argument = arg_value\n'
+    '    broker = BROKER_ADDRESS\n'
+    '\n'
+    'This allows running it with IoT-LAB "script" execution feature\n'
+)
+PARSER = common.MQTTAgentArgumentParser(
+    epilog=EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
+iotlabapi.parser_add_iotlabapi_args(PARSER)
+
+
+MANAGER_PROCESS = {
+    'serial': ['iotlab-mqtt-serial', 'ARGS_prefix', 'ARGS_mqtt'],
+    'node': ['iotlab-mqtt-node', 'ARGS_prefix', 'ARGS_mqtt', 'ARGS_iotlabapi'],
+    'radiosniffer': ['iotlab-mqtt-radiosniffer', 'ARGS_prefix', 'ARGS_mqtt',
+                     'ARGS_iotlabapi'],
+    'process': ['iotlab-mqtt-process', 'ARGS_prefix', 'ARGS_mqtt'],
+}
+
+
+def arguments_substitution_dict(prefix, **objs):
+    """Return dict of arguments list for ``prefix`` and ``**objs args`` list.
+
+    Construct a dict with 'ARG_{name}: [args_list]' entries in the dict.
+
+    For prefix, args will be ['--prefix', prefix].
+    For objects in ``**objs``, arguments list is got by calling
+    'to_argparse_list' method.
+    """
+    ret = {}
+    ret['ARGS_prefix'] = ['--prefix', prefix]
+
+    for name, obj in objs.items():
+        ret['ARGS_%s' % name] = obj.to_argparse_list()
+
+    return ret
+
+
+def process_arguments_dict(process_dict, args_dict):
+    """Return dict of processes with arguments.
+
+    Enrich process_dict arguments with args_dict values.
+    """
+    ret = {}
+    for name, args_list in process_dict.items():
+        ret[name] = _substitute_arguments(args_list, args_dict)
+    return ret
+
+
+def _substitute_arguments(args_list, args_dict):
+    """Return list of arguments.
+
+    >>> args_dict = {'ARGS_prefix': ['--prefix', 'PREFIX'],
+    ...              'ARGS_mqtt': ['--broker-port', '8884', 'localhost']}
+    >>> args_list = ['command', 'argument', 'ARGS_prefix', 'ARGS_mqtt']
+
+    >>> expected = ['command', 'argument', '--prefix', 'PREFIX',
+    ...             '--broker-port', '8884', 'localhost']
+
+    >>> _substitute_arguments(args_list, args_dict) == expected
+    True
+    """
+    return [arg for name in args_list for arg in args_dict.get(name, [name])]
+
+
+class MQTTManagerAgent(process.MQTTProcessAgent):
+    """Agent Manager Agent implementation for MQTT."""
+    AGENTTOPIC = 'iot-lab/manager/{site}'
+
+    def __init__(self, client, prefix='', agenttopic=None,
+                 process_args_dict=None):
+        # Default value
+        process_args_dict = process_args_dict or {}
+
+        super().__init__(client, prefix=prefix, agenttopic=agenttopic)
+
+        self.process_args_dict = process_args_dict
+
+    # Disable unused 'Process' methods
+
+    def cb_new(self, _):
+        """Alloc a new process id."""
+        return self._disabled_method_for_manager()
+
+    def cb_free(self, message):
+        """Free given process id."""
+        return self._disabled_method_for_manager()
+
+    def cb_procrun(self, message, procid):
+        """Run command for process id."""
+        return self._disabled_method_for_manager()
+
+    @staticmethod
+    def _disabled_method_for_manager():
+        return 'Method not available for manager'.encode('utf-8')
+
+    def start(self):
+        """Start Agent."""
+        super().start()
+        self.start_managed_processes()
+
+    def stop(self):
+        """Stop agent."""
+        self.process.stop()
+        super().stop()
+
+    def start_managed_processes(self):
+        """Start all managed processes."""
+        for name, args in self.process_args_dict.items():
+            self._start_process(name, args)
+
+    def _start_process(self, name, args):
+        """Start process ``name`` with ``args``."""
+        print('Starting managed process: %s' % name)
+        self.process.new(name)
+        self.process[name].run(args)
+
+    @classmethod
+    def from_opts_dict(cls, prefix, agenttopic=None, **kwargs):
+        """Create class from argparse entries."""
+        api = iotlabapi.IoTLABAPI.from_opts_dict(**kwargs)
+        client = mqttcommon.MQTTClient.from_opts_dict(**kwargs)
+
+        prefix = cls._prefix_set_expid_and_user_from_api(prefix, api)
+
+        args_dict = arguments_substitution_dict(
+            prefix, iotlabapi=api, mqtt=client)
+        process_args_dict = process_arguments_dict(MANAGER_PROCESS, args_dict)
+
+        return cls(client, prefix, agenttopic=agenttopic,
+                   process_args_dict=process_args_dict)
+
+    @staticmethod
+    def _prefix_set_expid_and_user_from_api(prefix, iotlab_api):
+        """Configure  ``prefix`` from ``iotlab_api``.
+
+        Replaces ``{prefix}`` and ``{expid}`` entries by their value.
+        """
+        user = iotlab_api.username
+        expid = iotlab_api.expid
+        return prefix.format(user=user, expid=expid)
+
+
+def arguments_from_argv_or_config(argv):
+    """Return parse_args argument from ``argv``.
+
+    Try reading arguments frmo config file or return regular arguments.
+    """
+    try:
+        # Read config file
+        (configfile,) = argv[1:]
+        return _args_from_configfile(configfile)
+    except (ValueError, IOError):
+        # Default
+        return argv[1:]
+
+
+def _args_from_configfile(cfgfile):
+    args_dict = _args_dict_from_configfile(cfgfile, section='DEFAULT')
+    return _args_from_args_dict(args_dict)
+
+
+def _args_dict_from_configfile(cfgfile, section='DEFAULT'):
+    """Read arguments dict from ``cfgfile`` section ``section``."""
+    cfg = configparser.ConfigParser()
+
+    # Read and error if non existent file
+    cfg.readfp(open(cfgfile), cfgfile)  # pylint:disable=deprecated-method
+
+    # Save to dict
+    return dict(cfg.items(section))
+
+
+def _args_from_args_dict(args_dict):
+    args = []
+    for name, value in args_dict.items():
+        if name.startswith('--'):
+            args.append(name)
+        args.append(value)
+
+    return args
+
+
+def main():
+    """Run manager agent."""
+    args = arguments_from_argv_or_config(sys.argv)
+    opts = PARSER.parse_args(args)
+
+    aggr = MQTTManagerAgent.from_opts_dict(**vars(opts))
+    aggr.run()

--- a/iotlabmqtt/manager.py
+++ b/iotlabmqtt/manager.py
@@ -1,5 +1,94 @@
 # -*- coding: utf-8 -*-
 
+r"""IoT-LAB MQTT Manager agent
+=============================
+
+Manager agent allows managing IoT-LAB MQTT agents.
+
+Manager agent base topic: ::
+
+   {prefix}/iot-lab/manager/{site}
+
+Every topics from manager agent topics start by this topic prefix
+
+:param prefix: configured prefix
+:param site: site where the agent is run
+
+.. note::
+
+   This is a restricted implementation of the Process agent.
+   All methods behave the same and should be looked at its documentation.
+
+At startup, all IoT-LAB agents are run as managed `process` and are accessible
+through the following topics.
+
+Topics Summary
+==============
+
+.. |proc|             replace::  ``{processagenttopic}``
+
+.. |ctllist|          replace::  |proc|\ ``/ctl/list``
+
+.. |procid|           replace::  |proc|\ ``/process/{procid}``
+.. |procctlpoll|      replace::  |procid|\ ``/ctl/poll``
+.. |procctlkill|      replace::  |procid|\ ``/ctl/kill``
+.. |procctlrerun|     replace::  |procid|\ ``/ctl/rerun``
+
+.. |fdin|             replace::  ``fd/stdin``
+.. |fdout|            replace::  ``fd/stdout``
+.. |fderr|            replace::  ``fd/stderr``
+.. |procstdin|        replace::  |procid|\ /\ |fdin|
+.. |procstdout|       replace::  |procid|\ /\ |fdout|
+.. |procstderr|       replace::  |procid|\ /\ |fderr|
+
+.. |retcode|          replace::  ``event/returncode``
+.. |procret|          replace::  |procid|\ /\ |retcode|
+
+.. |error_t|          replace::  |proc|\ ``/error/``
+.. |request|          replace::  :ref:`Request <RequestTopic>`
+.. |error|            replace::  :ref:`Error <ErrorTopic>`
+
+.. |request_topic|    replace::  *{topic}*/**request/{clientid}/{requestid}**
+.. |reply_topic|      replace::  *{topic}*/**reply/{clientid}/{requestid}**
+
+.. |outtopic|         replace::  Output
+.. |intopic|          replace::  Input
+
++-+---------------------------------------------------------------+-----------+
+| |Topic                                                          | Type      |
++=+===============================================================+===========+
+|  **Manager agent**                                                          |
++-+---------------------------------------------------------------+-----------+
+| ``{prefix}/iot-lab/manager/{site}``                                         |
++-+---------------------------------------------------------------+-----------+
+| ||error_t|                                                      | |error|   |
++-+---------------------------------------------------------------+-----------+
+|  **Process ids management**                                                 |
++-+---------------------------------------------------------------+-----------+
+| ||ctllist|                                                      ||request|  |
++-+---------------------------------------------------------------+-----------+
+|  **Process control**                                                        |
++-+---------------------------------------------------------------+-----------+
+| ||procctlpoll|                                                  ||request|  |
++-+---------------------------------------------------------------+-----------+
+| ||procctlkill|                                                  ||request|  |
++-+---------------------------------------------------------------+-----------+
+| ||procctlrerun|                                                 ||request|  |
++-+---------------------------------------------------------------+-----------+
+|  **Process file descriptors**                                               |
++-+---------------------------------------------------------------+-----------+
+| ||procstdin|                                                    | |intopic| |
++-+---------------------------------------------------------------+-----------+
+| ||procstdout|                                                   | |outtopic||
++-+---------------------------------------------------------------+-----------+
+| ||procstderr|                                                   | |outtopic||
++-+---------------------------------------------------------------+-----------+
+|  **Process events**                                                         |
++-+---------------------------------------------------------------+-----------+
+| ||procret|                                                      | |outtopic||
++-+---------------------------------------------------------------+-----------+
+"""
+
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 from builtins import *  # pylint:disable=W0401,W0614,W0622

--- a/iotlabmqtt/manager.py
+++ b/iotlabmqtt/manager.py
@@ -126,7 +126,7 @@ class MQTTManagerAgent(process.MQTTProcessAgent):
 
     def stop(self):
         """Stop agent."""
-        self.process.stop()
+        self.process.stop(timeout=15)
         super().stop()
 
     def start_managed_processes(self):

--- a/iotlabmqtt/mqttcommon.py
+++ b/iotlabmqtt/mqttcommon.py
@@ -162,6 +162,15 @@ class MQTTClient(mqtt.Client):
         """Create class from argparse entries."""
         return cls(broker, port=broker_port)
 
+    def to_argparse_list(self):
+        """Return arguments needed to create this object with PARSER."""
+        return [
+            '--broker-port', '%s' % self.port,
+            '--broker-username', self._username,
+            '--broker-password', self._password,
+            '%s' % self.server,
+        ]
+
 
 def _fmt_topic(topic, prefix='', static_fmt_dict=None):
     """Prepend prefix to prefix and update values from static_fmt_dict.

--- a/iotlabmqtt/tests/iotlabapi_tests.py
+++ b/iotlabmqtt/tests/iotlabapi_tests.py
@@ -157,6 +157,25 @@ class IoTLABAPITestInit(TestCaseImproved):
         out = ''
         self.assertEqual(self.stdout.getvalue(), out)
 
+    def test_to_argparse_list(self):
+        """Test IoTLABAPI.to_argparse_list."""
+        args = ['--experiment-id', '12345',
+                '--iotlab-user', 'us3rn4me',
+                '--iotlab-password', 'p4sswd']
+        opts = self.parser.parse_args(args)
+        api = iotlabapi.IoTLABAPI.from_opts_dict(**vars(opts))
+
+        # Create object using 'to_argparse_list'
+        new_opts = self.parser.parse_args(api.to_argparse_list())
+        new_api = iotlabapi.IoTLABAPI.from_opts_dict(**vars(new_opts))
+
+        self.assertEqual(api.expid, new_api.expid)
+        self.assertEqual(api.username, new_api.username)
+        self.assertEqual(api.password, new_api.password)
+
+        # to_argparse_list is stable
+        self.assertEqual(api.to_argparse_list(), new_api.to_argparse_list())
+
 
 class IoTLABAPITest(TestCaseImproved):
     """Test IoTLABAPI."""

--- a/iotlabmqtt/tests/iotlabapi_tests.py
+++ b/iotlabmqtt/tests/iotlabapi_tests.py
@@ -55,8 +55,8 @@ class IoTLABAPITestInit(TestCaseImproved):
         self.get_experiment.assert_called_with(api.api, 12345, 'state')
 
         self.assertEqual(api.expid, 12345)
-        self.assertEqual(api.api.auth.username, 'us3rn4me')
-        self.assertEqual(api.api.auth.password, 'p4sswd')
+        self.assertEqual(api.username, 'us3rn4me')
+        self.assertEqual(api.password, 'p4sswd')
 
         out = ''
         self.assertEqual(self.stdout.getvalue(), out)
@@ -75,8 +75,8 @@ class IoTLABAPITestInit(TestCaseImproved):
         self.get_experiment.assert_called_with(api.api, 12345, 'state')
         get_cred.assert_called_with(None, None)
         self.assertEqual(api.expid, 12345)
-        self.assertEqual(api.api.auth.username, 'user')
-        self.assertEqual(api.api.auth.password, 'password')
+        self.assertEqual(api.username, 'user')
+        self.assertEqual(api.password, 'password')
 
         out = ''
         self.assertEqual(self.stdout.getvalue(), out)
@@ -151,8 +151,8 @@ class IoTLABAPITestInit(TestCaseImproved):
         self.get_experiment.assert_called_with(api.api, 232323, 'state')
 
         self.assertEqual(api.expid, 232323)
-        self.assertEqual(api.api.auth.username, 'us3rn4me')
-        self.assertEqual(api.api.auth.password, 'p4sswd')
+        self.assertEqual(api.username, 'us3rn4me')
+        self.assertEqual(api.password, 'p4sswd')
 
         out = ''
         self.assertEqual(self.stdout.getvalue(), out)

--- a/iotlabmqtt/tests/manager_tests.py
+++ b/iotlabmqtt/tests/manager_tests.py
@@ -1,0 +1,79 @@
+# -*- coding:utf-8 -*-
+
+"""Manager agent tests."""
+
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+from builtins import *  # pylint:disable=W0401,W0614,W0622
+
+
+import os
+import tempfile
+import textwrap
+
+from iotlabmqtt import manager
+from . import TestCaseImproved
+
+# pylint:disable=invalid-name
+
+
+class ManagerArguentsTestFromConfig(TestCaseImproved):
+    """Test Arguments reading from configfile."""
+
+    def setUp(self):
+        self.configfile = tempfile.NamedTemporaryFile(mode='w+', delete=True)
+
+    def tearDown(self):
+        self.configfile.close()
+
+    def test_arguments_from_config_minimal(self):
+        """Test starting from args and configfile with minimal options."""
+        os.environ.pop('EXP_ID', '')
+        argv = ['localhost']
+
+        config = textwrap.dedent('''\
+        [DEFAULT]
+        broker = localhost
+        ''')
+        self.configfile.write(config)
+        self.configfile.flush()
+
+        argv = ['manager'] + argv
+        args = manager.arguments_from_argv_or_config(argv)
+        opts = manager.PARSER.parse_args(args)
+        self.assertIsNone(opts.experiment_id)
+
+        config_argv = ['manager', self.configfile.name]
+        config_args = manager.arguments_from_argv_or_config(config_argv)
+        config_opts = manager.PARSER.parse_args(config_args)
+        self.assertEqual(opts, config_opts)
+
+    def test_arguments_from_config_default(self):
+        """Test starting from args and configfile with basic options."""
+        argv = ['localhost', '--broker-port', '8883',
+                '--prefix', 'iotlabmqtt/test/prefix']
+        argv += ['--experiment-id', '12345',
+                 '--iotlab-user', 'us3rn4me',
+                 '--iotlab-password', 'p4sswd']
+
+        config = textwrap.dedent('''\
+        [DEFAULT]
+        --prefix = iotlabmqtt/test/prefix
+        --broker-port = 8883
+        --iotlab-user = us3rn4me
+        --iotlab-password = p4sswd
+        # Automatically deduced values when used with 'run_script'
+        --experiment-id = 12345
+        broker = localhost
+        ''')
+        self.configfile.write(config)
+        self.configfile.flush()
+
+        argv = ['manager'] + argv
+        args = manager.arguments_from_argv_or_config(argv)
+        opts = manager.PARSER.parse_args(args)
+
+        config_argv = ['manager', self.configfile.name]
+        config_args = manager.arguments_from_argv_or_config(config_argv)
+        config_opts = manager.PARSER.parse_args(config_args)
+        self.assertEqual(opts, config_opts)

--- a/iotlabmqtt/tests/mqttcommon_tests.py
+++ b/iotlabmqtt/tests/mqttcommon_tests.py
@@ -10,6 +10,7 @@ import os.path
 import threading
 
 import mock
+from iotlabmqtt import common
 from iotlabmqtt import mqttcommon
 from iotlabmqtt.clients import common as clientcommon
 from . import mqttclient_mock
@@ -69,6 +70,27 @@ class MQTTClientTest(AgentTest):
         agent = mqttclient_mock.MQTTClientMock('localhost', 1883)
         agent.connect_delay = 15
         self.assertRaises(RuntimeError, agent.start)
+
+    def test_to_argparse_list(self):
+        """Test MQTTClient.to_argparse_list."""
+        args = ['--broker-port', '8883', 'localhost']
+
+        parser = common.MQTTAgentArgumentParser()
+
+        opts = parser.parse_args(args)
+        client = mqttcommon.MQTTClient.from_opts_dict(**vars(opts))
+
+        new_opts = parser.parse_args(client.to_argparse_list())
+        new_client = mqttcommon.MQTTClient.from_opts_dict(**vars(new_opts))
+
+        # Are the same
+        self.assertEqual(client.server, new_client.server)
+        self.assertEqual(client.port, new_client.port)
+        self.assertEqual(client.topics, new_client.topics)
+
+        # to_argparse_list is stable
+        self.assertEqual(client.to_argparse_list(),
+                         new_client.to_argparse_list())
 
 
 class TopicTest(AgentTest):

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ ENTRY_POINTS = {
         'iotlab-mqtt-node = iotlabmqtt.node:main [node]',
         'iotlab-mqtt-radiosniffer = iotlabmqtt.radiosniffer:main [sniffer]',
         'iotlab-mqtt-process = iotlabmqtt.process:main',
+        'iotlab-mqtt-manager = iotlabmqtt.manager:main [server]',
 
         # Client script
         'iotlab-mqtt-clients = iotlabmqtt.clients:main',


### PR DESCRIPTION
A proposal to add a global manager that run all agents. It is based on "process" agent implementation.

At startup it defines all processes with the correct arguments.
It uses a "to_argparse_list" method to know arguments for each agent and calls the agents with the correct arguments.

There is an issue when providing iot-lab user password (and the same would be if using broker password)
WARNING: This should be changed, setting a password from command line is really bad. On IoT-LAB all users can see other users commands arguments. A solution could be to use an env variable.

This would require changing the way arguments are handled and passed to sub agents.