### PR TITLE
[WIP] Initial support for A8-m3 nodes

### DIFF
--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -212,6 +212,12 @@ class IoTLABAPI(object):
         from iotlabsshcli import open_a8
         nodes = self._nodes_for_num(archi, *nums)
 
+        # The M3 nodes have access to the socat tunnel all the time.
+        # This tries to mimic the behavior for the A8 nodes.
+        if  command != 'stop':
+            _socat = "nohup /etc/init.d/serial_redirection restart"
+            open_a8.run_cmd(self.config_ssh, nodes, _socat, False, False)
+
         if command == 'start':
             _result = self._opena8_command_start(open_a8, nodes)
             result = _result['run-cmd']

--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -121,10 +121,10 @@ class IoTLABAPI(object):
         """Update nodes ``archi`` and ``*nums`` with ``firmwarepath``."""
         if archi == 'm3' or archi == 'a8':
             return self.node_command('update', firmwarepath, archi, *nums)
-        else:
-            assert nums
-            msg = "'%s' architecture not supported." % (archi)
-            return self.retval(msg, *nums)
+
+        assert nums
+        msg = "'%s' architecture not supported." % (archi)
+        return self.retval(msg, *nums)
 
     def poweron(self, archi, *nums):
         """Power ON nodes ``archi`` and ``*nums``."""
@@ -199,11 +199,11 @@ class IoTLABAPI(object):
         if archi == 'm3':
             result = iotlabcli.node.node_command(self.api, command, self.expid,
                                                  nodes, cmd_opt)
-        elif archi =='a8':
+        elif archi == 'a8':
             # NOTE: Open-a8-node use different syntax and dictionary format
-            config_ssh = {'user':self.user, 'exp_id':self.expid}
+            config_ssh = {'user': self.user, 'exp_id': self.expid}
             result_ = iotlabsshcli.open_a8.flash_m3(config_ssh, nodes, cmd_opt)
-            result  = result_['flash-m3']
+            result = result_['flash-m3']
 
         return self._command_result_to_retval(result, archi)
 
@@ -221,7 +221,7 @@ class IoTLABAPI(object):
 
                 # WARNING 'node-a8' is not 'a8'
                 if archi == 'a8':
-                    _ , archi_ = archi_.split('-',1)
+                    _, archi_ = archi_.split('-', 1)
 
                 numstr = str(num)
                 assert (archi_, site_) == (archi, self.site)

--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -276,7 +276,7 @@ class IoTLABAPI(object):
         return result
 
 
-def node_from_infos(archi, num, site, is_nodea8):
+def node_from_infos(archi, num, site, is_nodea8=False):
     # pylint:disable=unused-argument
     """Node hostname from infos.
 

--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -211,7 +211,7 @@ class IoTLABAPI(object):
         """ opensshcli make use of IoTLAB API in a different approach
         """
         from iotlabsshcli import open_a8
-        nodes = self._nodes_for_num(archi, *nums, is_nodea8=True)
+        nodes = self._nodes_for_num(archi, True, *nums)
 
         # The M3 nodes have access to the socat tunnel all the time.
         # This tries to mimic the behavior for the A8 nodes.
@@ -252,12 +252,12 @@ class IoTLABAPI(object):
 
     def _node_command(self, command, cmd_opt, archi, *nums):
         import iotlabcli.node
-        nodes = self._nodes_for_num(archi, *nums)
+        nodes = self._nodes_for_num(archi, False, *nums)
         result = iotlabcli.node.node_command(self.api, command, self.expid,
                                              nodes, cmd_opt)
         return self._command_result_to_retval(result, archi)
 
-    def _nodes_for_num(self, archi, *nums, is_nodea8=False):
+    def _nodes_for_num(self, archi, is_nodea8=False, *nums):
         """Return nodes address list for `archi` and `*nums`."""
         return [node_from_infos(archi, num, self.site, is_nodea8)
                 for num in nums]

--- a/iotlabmqtt/iotlabapi.py
+++ b/iotlabmqtt/iotlabapi.py
@@ -231,18 +231,16 @@ class IoTLABAPI(object):
         return self._command_result_to_retval(result, archi)
 
     def _opena8_command_stop(self, a8api, nodes):
-        """ opensshcli does not have a native function"""
+        """ opensshcli does not have native function for starting the node """
 
-        #TODO: Stop the SOCAT tunnel
         command = self.A8M3_OPENOCD_RESET_HALT_CMD
-        return a8api.run_cmd(self.config_ssh, nodes, command, False, True)
+        return a8api.run_cmd(self.config_ssh, nodes, command, False, False)
 
     def _opena8_command_start(self, a8api, nodes):
-        """ opensshcli does not have a native function"""
+        """ opensshcli does not have native function for stopping the node"""
 
-        #TODO: Starts the SOCAT tunnel
         command = self.A8M3_OPENOCD_RESET_RUN_CMD
-        return a8api.run_cmd(self.config_ssh, nodes, command, False, True)
+        return a8api.run_cmd(self.config_ssh, nodes, command, False, False)
 
     def _node_command(self, command, cmd_opt, archi, *nums):
         import iotlabcli.node

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ ENTRY_POINTS = {
 }
 
 EXTRAS_REQUIRE = {
-    'node': ['iotlabcli>=2.4.0'],
+    'node': ['iotlabcli>=2.4.0', 'iotlabsshcli>=0.1.0'],
     'sniffer': ['iotlabcli>=2.4.0'],
 }
 


### PR DESCRIPTION
I'm starting to add support for using MQTT with A8-m3 nodes. 

The first commit is adding support only for  uploading firmwares  as I want your opinion with the lines modified in `def update()`.  I consider this option to be valid as there are other nodes supported not tested with MQTT (samr21, WSN430 ).

Also, the options available for A8 are sometimes different than those of the M3. By example the m3 (`node-cli`) does not support erasing the node while  the A8 can do it.  Therefore, I was thinking on two possible options for adding it to MQTT:

1) Adding a new option to the node agent (`erase a8 <num>`) for erasing that is only supported by the A8. 
2) Modifying `update` so if `update a8 <num>` (without firmware) is given, assume that we are deleting instead of trying loading the idle firmware.

