### PR TITLE
[WIP] Fixing tox tests 

### DIFF
--- a/iotlabmqtt/asyncconnection.py
+++ b/iotlabmqtt/asyncconnection.py
@@ -56,7 +56,7 @@ class NodeConnection(asyncore.dispatcher_with_send):
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             self.connect(self.address)
-        except:  # pylint:disable=broad-except,bare-except
+        except:  # noqa: E722 pylint:disable=broad-except,bare-except
             self.handle_error()
 
     def handle_connect(self):


### PR DESCRIPTION
This PR is an attempt of fixing issue #12. 

What is does:

* [x] A flake8 statement for ignoring bare-except is added to the line with an already pre-existent plyint statement for the same purpose.
* [ ] Upgrade the mock clients ([iotlabmqtt/tests/mqttclient_mock.py:35](https://github.com/iot-lab/iot-lab-mqtt/blob/master/iotlabmqtt/tests/mqttclient_mock.py#L35)) for working better with #11 

